### PR TITLE
[IPNFT - SC script]: Define the `hashInPoseidon2()` with the `@zkpassport/poseidon2` --> Successful to run the script and generate a `"Poseidon2 Hash"` ⭕️

### DIFF
--- a/IP-NFT_with_ZK-certificate/README.md
+++ b/IP-NFT_with_ZK-certificate/README.md
@@ -45,6 +45,15 @@ sh script/utils/poseidon-hash-generator/runningScript_poseidonHashGenerator.sh
 
 <br>
 
+- Run the `poseidon2HashGenerator.ts`
+```bash
+sh script/utils/poseidon2-hash-generator/runningScript_poseidon2HashGenerator.sh
+```
+(Ref: https://nodejs.org/en/learn/typescript/run#running-typescript-with-a-runner )
+
+
+<br>
+
 <hr>
 
 # Noir with Foundry

--- a/IP-NFT_with_ZK-certificate/script/utils/poseidon2-hash-generator/package.json
+++ b/IP-NFT_with_ZK-certificate/script/utils/poseidon2-hash-generator/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@zkpassport/poseidon2": "^0.6.1"
+  }
+}

--- a/IP-NFT_with_ZK-certificate/script/utils/poseidon2-hash-generator/poseidon2HashGenerator.ts
+++ b/IP-NFT_with_ZK-certificate/script/utils/poseidon2-hash-generator/poseidon2HashGenerator.ts
@@ -1,0 +1,37 @@
+import { poseidon2Hash } from "@zkpassport/poseidon2"
+
+/** 
+ * @notice - Get the poseidon hash from the specified data
+ */
+function hashInPoseidon2() {
+  // Hash an array of bigints
+  const input = [1n, 2n, 3n]
+  const hash = poseidon2Hash(input)
+  console.log(`hash (Poseidon2 hash): ${ hash }`); // Returns a single bigint hash value
+
+  return hash;
+}
+
+
+/**
+ * @notice - The main function
+ */
+function main() {
+//function main(): Promise<bigint> { // Mark the function as async
+  // const data1 = 100;
+  // const data2 = 200;
+  // const data3 = 300;
+  const hash = hashInPoseidon2(); // Await the promise
+  console.log(`hash (Poseidon2 hash): ${ hash }`); // Returns a single bigint hash value
+  //return hash; // Return the resolved value
+}
+
+/**
+ * @notice - Execute the main function
+ */
+main();
+// main().then((result) => {
+//   console.log(`Result: ${result}`);
+// }).catch((error) => {
+//   console.error(`Error: ${error}`);
+// });

--- a/IP-NFT_with_ZK-certificate/script/utils/poseidon2-hash-generator/runningScript_poseidon2HashGenerator.sh
+++ b/IP-NFT_with_ZK-certificate/script/utils/poseidon2-hash-generator/runningScript_poseidon2HashGenerator.sh
@@ -1,0 +1,9 @@
+echo "Load the environment variables from the .env file..."
+#source .env
+. ./.env
+
+echo "Run the poseidon2HashGenerator.ts..."
+npx tsx script/utils/poseidon2-hash-generator/poseidon2HashGenerator.ts  # Success
+#npx ts-node script/utils/poseidon2-hash-generator/poseidon2HashGenerator.ts
+
+# See the detail of how to run a Typescript file in shell script: https://nodejs.org/en/learn/typescript/run#running-typescript-with-a-runner

--- a/IP-NFT_with_ZK-certificate/script/utils/poseidon2-hash-generator/tsconfig.json
+++ b/IP-NFT_with_ZK-certificate/script/utils/poseidon2-hash-generator/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+      "target": "ES2020",
+      "module": "commonjs",
+      "moduleResolution": "node",
+      "strict": true,
+      "esModuleInterop": true,
+      "resolveJsonModule": true,
+      "outDir": "./dist",
+      "rootDir": "./src"
+    },
+    "include": ["src/**/*"]
+  }

--- a/IP-NFT_with_ZK-certificate/script/utils/poseidon2-hash-generator/types.ts
+++ b/IP-NFT_with_ZK-certificate/script/utils/poseidon2-hash-generator/types.ts
@@ -1,0 +1,15 @@
+import { Noir } from '@noir-lang/noir_js';
+import { BarretenbergBackend } from '@noir-lang/backend_barretenberg';
+import { CompiledCircuit, ProofData } from '@noir-lang/types';
+
+export type Circuits = CompiledCircuit;
+
+export type BackendInstances = BarretenbergBackend;
+
+export type Noirs = Noir;
+
+export interface ProofArtifacts extends ProofData {
+  proofAsFields: string;
+  vkAsFields: string;
+  vkHash: string;
+}


### PR DESCRIPTION
# 【Noir】`zkpassport/poseidon2` for generating a Poseidon2 Hash in Typescript

## `zkpassport/poseidon2`
- Repo（`zkpassport/poseidon2`）：https://github.com/zkpassport/poseidon2
```typescript
import { poseidon2Hash } from "@zkpassport/poseidon2"

// Hash an array of bigints
const input = [1n, 2n, 3n]
const hash = poseidon2Hash(input)
console.log(hash) // Returns a single bigint hash value
```

- Source：[Awesome Noir ](https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#library-related)
> [Poseidon2 in TypeScript](https://github.com/zkpassport/poseidon2) - a Poseidon2 library in pure TypeScript with support for the implementation used by Noir (over BN254)