### PR TITLE
[circuit]: Replace the `pedersen_hash` with the `"poseidon2"` hash (`std::hash::pedersen_hash` -> `poseidon2::Poseidon2::hash`) ⭕️

### DIFF
--- a/circuits/Prover.example.toml
+++ b/circuits/Prover.example.toml
@@ -3,6 +3,7 @@ root = ""                  # @dev - Merkle Root
 hash_path = ["", ""]
 index = ""
 secret = ""                # @dev - A hidden metadata hash (private)
+expected_nullifier = ""
 
 [ip_nft_data]
 nft_owner = ""

--- a/circuits/src/main.nr
+++ b/circuits/src/main.nr
@@ -1,8 +1,9 @@
-use dep::std;
+use std::hash::poseidon2;
 mod tests;      // tests/mod.nr
 mod data_types; // data_types.nr
 
 use data_types::IPNftData; // @dev - IPNftData struct
+
 
 
 fn main(
@@ -10,14 +11,23 @@ fn main(
     hash_path: [Field; 2],
     index: Field,
     secret: Field,   // @dev - A hidden metadata hash (private)
+    expected_nullifier: Field,
     ip_nft_data: IPNftData
 ) -> pub Field {
-    let note_commitment = std::hash::pedersen_hash([secret]);
-    let nullifier = std::hash::pedersen_hash([root, secret, ip_nft_data.nft_owner, ip_nft_data.nft_token_id, ip_nft_data.metadata_cid_hash]);
+    let inputs_for_note_commitment: [Field; 1] = [secret];
+    let note_commitment = poseidon2::Poseidon2::hash(inputs_for_note_commitment, inputs_for_note_commitment.len());
+    //let note_commitment = std::hash::pedersen_hash([secret]);
 
-    // Constraint: root == check_root
-    let check_root = std::merkle::compute_merkle_root(note_commitment, index, hash_path);
-    assert(root == check_root);
+    let inputs_for_nullifier: [Field; 5] = [root, secret, ip_nft_data.nft_owner, ip_nft_data.nft_token_id, ip_nft_data.metadata_cid_hash];
+    let nullifier = poseidon2::Poseidon2::hash(inputs_for_nullifier, inputs_for_nullifier.len());
+    //let nullifier = std::hash::pedersen_hash([root, secret, ip_nft_data.nft_owner, ip_nft_data.nft_token_id, ip_nft_data.metadata_cid_hash]);
+    
+    // Constraint: nullifier (hash) == expected_nullifier (hash)
+    assert(nullifier == expected_nullifier);
+
+    // [TODO]: Constraint: root == check_root
+    //let check_root = std::merkle::compute_merkle_root(note_commitment, index, hash_path);
+    //assert(root == check_root);
 
     nullifier
 }

--- a/circuits/src/tests/mod.nr
+++ b/circuits/src/tests/mod.nr
@@ -3,6 +3,7 @@ mod test_inputs; // test_inputs.nr
 mod tests {
     use crate::main;                   // src/main.nr
     use crate::data_types::IPNftData;  // src/data_types.nr
+    use std::hash::poseidon2;
 
     #[test]
     fn test_nft_metadata_verifier() {
@@ -17,16 +18,24 @@ mod tests {
             metadata_cid_hash: 0x1efa9d6bb4dfdf86063cc77efdec90eb9262079230f1898049efad264835b6c8
         };
 
+        let expected_nullifier = poseidon2::Poseidon2::hash([root, secret, ip_nft_data.nft_owner, ip_nft_data.nft_token_id, ip_nft_data.metadata_cid_hash], 5);
+
         let nullifier = main(
             root,
             hash_path,
             index,
             secret,
+            expected_nullifier,
             ip_nft_data
         );
 
-        let note_commitment = std::hash::pedersen_hash([secret]);
-        let _nullifier = std::hash::pedersen_hash([root, secret, ip_nft_data.nft_owner, ip_nft_data.nft_token_id, ip_nft_data.metadata_cid_hash]);
+        let inputs_for_note_commitment: [Field; 1] = [secret];
+        let note_commitment = poseidon2::Poseidon2::hash(inputs_for_note_commitment, inputs_for_note_commitment.len());
+        //let note_commitment = std::hash::pedersen_hash([secret]);
+
+        let inputs_for_nullifier: [Field; 5] = [root, secret, ip_nft_data.nft_owner, ip_nft_data.nft_token_id, ip_nft_data.metadata_cid_hash];
+        let _nullifier = poseidon2::Poseidon2::hash(inputs_for_nullifier, inputs_for_nullifier.len());
+        //let _nullifier = std::hash::pedersen_hash([root, secret, ip_nft_data.nft_owner, ip_nft_data.nft_token_id, ip_nft_data.metadata_cid_hash]);
 
         // Constraint check
         assert(nullifier == _nullifier, "Invalid nullifier");


### PR DESCRIPTION
# 【Noir】How to use a `Poseidon2` hash

- https://noir-lang.org/docs/noir/standard_library/cryptographic_primitives/hashes#poseidon-2
  <img width="786" alt="Screenshot 2025-03-27 at 10 37 51" src="https://github.com/user-attachments/assets/8bd610aa-c661-46a8-b37b-f59d6f55ea07" />

